### PR TITLE
CI: Don't split tests on Windows Python 3.10

### DIFF
--- a/.github/workflows/python-dev.yml
+++ b/.github/workflows/python-dev.yml
@@ -24,8 +24,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
         pytest_target: ["pandas/tests/[a-h]*", "pandas/tests/[i-z]*"]
+        include:
+          # No need to split tests on windows
+          - os: windows-latest
 
     name: actions-310-dev
     timeout-minutes: 80


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them
- [ ] whatsnew entry
