### PR TITLE
change np_datetime.c references to be to the library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -543,7 +543,8 @@ ext_data = {
     "_libs.tslibs.offsets": {
         "pyxfile": "_libs/tslibs/offsets",
         "depends": tseries_depends,
-        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime.c"],
+        "libraries": ["np_datetime"],
+        #        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime.c"],
     },
     "_libs.tslibs.parsing": {
         "pyxfile": "_libs/tslibs/parsing",
@@ -574,12 +575,14 @@ ext_data = {
     "_libs.tslibs.tzconversion": {
         "pyxfile": "_libs/tslibs/tzconversion",
         "depends": tseries_depends,
-        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime.c"],
+        "libraries": ["np_datetime"],
+        #        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime.c"],
     },
     "_libs.tslibs.vectorized": {
         "pyxfile": "_libs/tslibs/vectorized",
         "depends": tseries_depends,
-        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime.c"],
+        "libraries": ["np_datetime"],
+        #        "sources": ["pandas/_libs/tslibs/src/datetime/np_datetime.c"],
     },
     "_libs.testing": {"pyxfile": "_libs/testing"},
     "_libs.window.aggregations": {


### PR DESCRIPTION
Made changes to setup.py to remove `np_datetime.c` references as sources and refer back to the library.

